### PR TITLE
Remove E2E encryption badges from admin UI

### DIFF
--- a/client/lib/encryption.ts
+++ b/client/lib/encryption.ts
@@ -94,7 +94,10 @@ function safeDecrypt(encryptedText: string, key: string, iv: CryptoJS.lib.WordAr
       throw error;
     }
 
-    console.error('Safe decrypt failed:', error);
+    // Only log unexpected errors, not expected decryption failures
+    if (!error.message.includes('Malformed UTF-8')) {
+      console.error('Safe decrypt failed:', error);
+    }
     throw new Error(`Decryption failed: ${error.message}`);
   }
 }

--- a/client/lib/encryption.ts
+++ b/client/lib/encryption.ts
@@ -72,7 +72,7 @@ function safeDecrypt(encryptedText: string, key: string, iv: CryptoJS.lib.WordAr
       utf8String = decrypted.toString(CryptoJS.enc.Utf8);
     } catch (utf8Error) {
       // UTF-8 conversion failed - likely wrong key or incompatible encryption format
-      console.error('UTF-8 conversion failed:', utf8Error);
+      // Don't log this as error since it's expected for incompatible data
       throw new Error('Incompatible encryption format or wrong decryption key');
     }
 

--- a/client/lib/encryption.ts
+++ b/client/lib/encryption.ts
@@ -95,17 +95,26 @@ export function decryptReportData(encryptedData: EncryptedData): {
       }).toString(CryptoJS.enc.Utf8)
     : undefined;
 
-  const decryptedVideoMetadata = encryptedData.encryptedVideoMetadata
-    ? JSON.parse(
-        CryptoJS.AES.decrypt(
-          encryptedData.encryptedVideoMetadata,
-          ENCRYPTION_KEY,
-          {
-            iv,
-          },
-        ).toString(CryptoJS.enc.Utf8),
-      )
-    : undefined;
+  let decryptedVideoMetadata: any = undefined;
+  if (encryptedData.encryptedVideoMetadata) {
+    try {
+      const decryptedMetadataString = CryptoJS.AES.decrypt(
+        encryptedData.encryptedVideoMetadata,
+        ENCRYPTION_KEY,
+        {
+          iv,
+        },
+      ).toString(CryptoJS.enc.Utf8);
+
+      // Only parse if we have a non-empty string
+      if (decryptedMetadataString && decryptedMetadataString.trim()) {
+        decryptedVideoMetadata = JSON.parse(decryptedMetadataString);
+      }
+    } catch (error) {
+      console.error("Failed to decrypt or parse video metadata:", error);
+      decryptedVideoMetadata = undefined;
+    }
+  }
 
   return {
     message: decryptedMessage,

--- a/client/lib/encryption.ts
+++ b/client/lib/encryption.ts
@@ -155,7 +155,10 @@ export function decryptReportData(encryptedData: EncryptedData): {
       video_metadata: decryptedVideoMetadata,
     };
   } catch (error) {
-    console.error('Legacy decryption failed:', error);
+    // Don't log expected decryption failures to reduce console noise
+    if (!error.message.includes('Incompatible encryption') && !error.message.includes('Malformed UTF-8')) {
+      console.error('Legacy decryption failed:', error);
+    }
     throw new Error(`Legacy decryption failed: ${error.message}`);
   }
 }

--- a/client/lib/secure-encryption.ts
+++ b/client/lib/secure-encryption.ts
@@ -331,12 +331,21 @@ export class SecureE2EEManager {
     }
 
     if (encryptedData.encryptedVideoMetadata) {
-      const decryptedMetadataString = this.decryptField(
-        encryptedData.encryptedVideoMetadata,
-        keys.encryptionKey,
-        iv,
-      );
-      decryptedVideoMetadata = JSON.parse(decryptedMetadataString);
+      try {
+        const decryptedMetadataString = this.decryptField(
+          encryptedData.encryptedVideoMetadata,
+          keys.encryptionKey,
+          iv,
+        );
+
+        // Only parse if we have a non-empty string
+        if (decryptedMetadataString && decryptedMetadataString.trim()) {
+          decryptedVideoMetadata = JSON.parse(decryptedMetadataString);
+        }
+      } catch (error) {
+        console.error("Failed to decrypt or parse video metadata in secure encryption:", error);
+        decryptedVideoMetadata = undefined;
+      }
     }
 
     console.log("✅ Report data decrypted successfully");

--- a/client/lib/secure-encryption.ts
+++ b/client/lib/secure-encryption.ts
@@ -265,9 +265,10 @@ export class SecureE2EEManager {
     // Use provided keyPair or current session keys
     const keys = keyPair || this.currentKeyPair;
     if (!keys) {
-      const errorMsg = keyPair === undefined && !this.currentKeyPair
-        ? "No decryption keys available - missing sessionId for admin key generation"
-        : "No decryption keys available";
+      const errorMsg =
+        keyPair === undefined && !this.currentKeyPair
+          ? "No decryption keys available - missing sessionId for admin key generation"
+          : "No decryption keys available";
       throw new Error(errorMsg);
     }
 
@@ -343,7 +344,10 @@ export class SecureE2EEManager {
           decryptedVideoMetadata = JSON.parse(decryptedMetadataString);
         }
       } catch (error) {
-        console.error("Failed to decrypt or parse video metadata in secure encryption:", error);
+        console.error(
+          "Failed to decrypt or parse video metadata in secure encryption:",
+          error,
+        );
         decryptedVideoMetadata = undefined;
       }
     }

--- a/client/lib/secure-encryption.ts
+++ b/client/lib/secure-encryption.ts
@@ -265,7 +265,10 @@ export class SecureE2EEManager {
     // Use provided keyPair or current session keys
     const keys = keyPair || this.currentKeyPair;
     if (!keys) {
-      throw new Error("No decryption keys available");
+      const errorMsg = keyPair === undefined && !this.currentKeyPair
+        ? "No decryption keys available - missing sessionId for admin key generation"
+        : "No decryption keys available";
+      throw new Error(errorMsg);
     }
 
     // Verify data integrity first

--- a/client/pages/Admin.tsx
+++ b/client/pages/Admin.tsx
@@ -329,7 +329,10 @@ export default function Admin() {
             });
 
             // Use enhanced decryption with admin keys
-            return secureE2EE.decryptReportData(report.encrypted_data, adminKeys);
+            return secureE2EE.decryptReportData(
+              report.encrypted_data,
+              adminKeys,
+            );
           } else {
             // No sessionId means this was encrypted with legacy system
             console.log("🔄 No sessionId found, using legacy decryption");
@@ -337,10 +340,12 @@ export default function Admin() {
           }
         } catch (error) {
           // Don't log expected encryption errors
-          if (!error.message?.includes("No decryption keys available") &&
-              !error.message?.includes("sessionId") &&
-              !error.message?.includes("Incompatible encryption") &&
-              !error.message?.includes("Legacy decryption failed")) {
+          if (
+            !error.message?.includes("No decryption keys available") &&
+            !error.message?.includes("sessionId") &&
+            !error.message?.includes("Incompatible encryption") &&
+            !error.message?.includes("Legacy decryption failed")
+          ) {
             console.error("Failed to decrypt report:", error);
           }
 
@@ -349,22 +354,31 @@ export default function Admin() {
             return legacyDecrypt(report.encrypted_data);
           } catch (legacyError) {
             // Only log unexpected errors, not expected decryption failures
-            if (!legacyError.message?.includes("Incompatible encryption") &&
-                !legacyError.message?.includes("Malformed UTF-8") &&
-                !legacyError.message?.includes("Legacy decryption failed") &&
-                !legacyError.message?.includes("wrong decryption key")) {
+            if (
+              !legacyError.message?.includes("Incompatible encryption") &&
+              !legacyError.message?.includes("Malformed UTF-8") &&
+              !legacyError.message?.includes("Legacy decryption failed") &&
+              !legacyError.message?.includes("wrong decryption key")
+            ) {
               console.error("Legacy decryption also failed:", legacyError);
             }
 
             // Provide clean, user-friendly error messages
             let errorMessage = "[Encrypted Report - Cannot Display]";
-            if (legacyError instanceof SyntaxError && legacyError.message.includes("JSON")) {
+            if (
+              legacyError instanceof SyntaxError &&
+              legacyError.message.includes("JSON")
+            ) {
               errorMessage = "[Encrypted Report - Metadata Issue]";
-            } else if (legacyError.message?.includes("Malformed UTF-8") ||
-                       legacyError.message?.includes("Incompatible encryption format")) {
+            } else if (
+              legacyError.message?.includes("Malformed UTF-8") ||
+              legacyError.message?.includes("Incompatible encryption format")
+            ) {
               errorMessage = "[Encrypted Report - Incompatible Format]";
-            } else if (legacyError.message?.includes("corrupted data") ||
-                       legacyError.message?.includes("null bytes")) {
+            } else if (
+              legacyError.message?.includes("corrupted data") ||
+              legacyError.message?.includes("null bytes")
+            ) {
               errorMessage = "[Encrypted Report - Data Corrupted]";
             }
 
@@ -625,11 +639,15 @@ export default function Admin() {
                       {report.is_encrypted ? (
                         <span className="flex items-center gap-2">
                           <Lock className="w-4 h-4 text-primary" />
-                          <span className={
-                            getDecryptedReport(report).message.startsWith("[Encrypted Report")
-                              ? "italic text-muted-foreground"
-                              : ""
-                          }>
+                          <span
+                            className={
+                              getDecryptedReport(report).message.startsWith(
+                                "[Encrypted Report",
+                              )
+                                ? "italic text-muted-foreground"
+                                : ""
+                            }
+                          >
                             {getDecryptedReport(report).message}
                           </span>
                         </span>
@@ -694,12 +712,16 @@ export default function Admin() {
                                   )}
                                 </Label>
                                 <div className="mt-2 p-4 bg-muted rounded-lg">
-                                  <p className={`whitespace-pre-wrap ${
-                                    selectedReport.is_encrypted &&
-                                    getDecryptedReport(selectedReport).message.startsWith("[Encrypted Report")
-                                      ? "italic text-muted-foreground"
-                                      : ""
-                                  }`}>
+                                  <p
+                                    className={`whitespace-pre-wrap ${
+                                      selectedReport.is_encrypted &&
+                                      getDecryptedReport(
+                                        selectedReport,
+                                      ).message.startsWith("[Encrypted Report")
+                                        ? "italic text-muted-foreground"
+                                        : ""
+                                    }`}
+                                  >
                                     {selectedReport.is_encrypted
                                       ? getDecryptedReport(selectedReport)
                                           .message

--- a/client/pages/Admin.tsx
+++ b/client/pages/Admin.tsx
@@ -347,10 +347,14 @@ export default function Admin() {
           let errorMessage = "[DECRYPTION ERROR - Unable to decrypt report]";
           if (legacyError instanceof SyntaxError && legacyError.message.includes("JSON")) {
             errorMessage = "[DECRYPTION ERROR - Corrupted video metadata]";
-          } else if (legacyError.message?.includes("Malformed UTF-8") || legacyError.message?.includes("invalid or empty data")) {
+          } else if (legacyError.message?.includes("Malformed UTF-8")) {
             errorMessage = "[DECRYPTION ERROR - Wrong encryption key or corrupted data]";
+          } else if (legacyError.message?.includes("corrupted data") || legacyError.message?.includes("null bytes")) {
+            errorMessage = "[DECRYPTION ERROR - Data corruption detected]";
           } else if (legacyError.message?.includes("Legacy decryption failed")) {
             errorMessage = "[DECRYPTION ERROR - Encryption format incompatible]";
+          } else if (legacyError.message?.includes("null data")) {
+            errorMessage = "[DECRYPTION ERROR - Empty encrypted data]";
           }
 
           return {

--- a/client/pages/Admin.tsx
+++ b/client/pages/Admin.tsx
@@ -638,7 +638,13 @@ export default function Admin() {
                       {report.is_encrypted ? (
                         <span className="flex items-center gap-2">
                           <Lock className="w-4 h-4 text-primary" />
-                          {getDecryptedReport(report).message}
+                          <span className={
+                            getDecryptedReport(report).message.startsWith("[Encrypted Report")
+                              ? "italic text-muted-foreground"
+                              : ""
+                          }>
+                            {getDecryptedReport(report).message}
+                          </span>
                         </span>
                       ) : (
                         report.message

--- a/client/pages/Admin.tsx
+++ b/client/pages/Admin.tsx
@@ -333,9 +333,8 @@ export default function Admin() {
 
         // Fallback to legacy decryption if enhanced fails
         try {
-          const {
-            decryptReportData: legacyDecrypt,
-          } = require("@/lib/encryption");
+          // Import legacy decryption function properly for browser environment
+          const { decryptReportData: legacyDecrypt } = await import("@/lib/encryption");
           console.log("🔄 Falling back to legacy decryption");
           return legacyDecrypt(report.encrypted_data);
         } catch (legacyError) {

--- a/client/pages/Admin.tsx
+++ b/client/pages/Admin.tsx
@@ -342,8 +342,17 @@ export default function Admin() {
           return legacyDecrypt(report.encrypted_data);
         } catch (legacyError) {
           console.error("Legacy decryption also failed:", legacyError);
+
+          // Provide more specific error messages based on error type
+          let errorMessage = "[DECRYPTION ERROR - Unable to decrypt report]";
+          if (legacyError instanceof SyntaxError && legacyError.message.includes("JSON")) {
+            errorMessage = "[DECRYPTION ERROR - Corrupted video metadata]";
+          } else if (legacyError.message?.includes("Malformed UTF-8")) {
+            errorMessage = "[DECRYPTION ERROR - Invalid encryption format]";
+          }
+
           return {
-            message: "[DECRYPTION ERROR - Unable to decrypt report]",
+            message: errorMessage,
             category: "encrypted",
             photo_url: undefined,
             video_url: undefined,

--- a/client/pages/Admin.tsx
+++ b/client/pages/Admin.tsx
@@ -347,8 +347,10 @@ export default function Admin() {
           let errorMessage = "[DECRYPTION ERROR - Unable to decrypt report]";
           if (legacyError instanceof SyntaxError && legacyError.message.includes("JSON")) {
             errorMessage = "[DECRYPTION ERROR - Corrupted video metadata]";
-          } else if (legacyError.message?.includes("Malformed UTF-8")) {
-            errorMessage = "[DECRYPTION ERROR - Invalid encryption format]";
+          } else if (legacyError.message?.includes("Malformed UTF-8") || legacyError.message?.includes("invalid or empty data")) {
+            errorMessage = "[DECRYPTION ERROR - Wrong encryption key or corrupted data]";
+          } else if (legacyError.message?.includes("Legacy decryption failed")) {
+            errorMessage = "[DECRYPTION ERROR - Encryption format incompatible]";
           }
 
           return {

--- a/client/pages/Admin.tsx
+++ b/client/pages/Admin.tsx
@@ -350,7 +350,9 @@ export default function Admin() {
           } catch (legacyError) {
             // Only log unexpected errors, not expected decryption failures
             if (!legacyError.message?.includes("Incompatible encryption") &&
-                !legacyError.message?.includes("Malformed UTF-8")) {
+                !legacyError.message?.includes("Malformed UTF-8") &&
+                !legacyError.message?.includes("Legacy decryption failed") &&
+                !legacyError.message?.includes("wrong decryption key")) {
               console.error("Legacy decryption also failed:", legacyError);
             }
 

--- a/client/pages/Admin.tsx
+++ b/client/pages/Admin.tsx
@@ -594,23 +594,6 @@ export default function Admin() {
                             : report.category,
                         )}
                         {getSeverityBadge(report.severity)}
-                        {report.is_encrypted ? (
-                          <Badge
-                            variant="secondary"
-                            className="bg-green-100 text-green-800 border-green-300"
-                          >
-                            <Lock className="w-3 h-3 mr-1" />
-                            E2E Encrypted
-                          </Badge>
-                        ) : (
-                          <Badge
-                            variant="outline"
-                            className="bg-amber-50 text-amber-700 border-amber-300"
-                          >
-                            <Lock className="w-3 h-3 mr-1 opacity-50" />
-                            Plain Text
-                          </Badge>
-                        )}
                         {(report.photo_url ||
                           (report.is_encrypted &&
                             getDecryptedReport(report).photo_url)) && (

--- a/client/pages/Admin.tsx
+++ b/client/pages/Admin.tsx
@@ -54,6 +54,7 @@ import {
   UpdateReportRequest,
 } from "@shared/api";
 import { secureE2EE } from "@/lib/secure-encryption";
+import { decryptReportData as legacyDecrypt } from "@/lib/encryption";
 import { notificationService } from "@/lib/notifications";
 
 export default function Admin() {

--- a/client/pages/Admin.tsx
+++ b/client/pages/Admin.tsx
@@ -707,7 +707,12 @@ export default function Admin() {
                                   )}
                                 </Label>
                                 <div className="mt-2 p-4 bg-muted rounded-lg">
-                                  <p className="whitespace-pre-wrap">
+                                  <p className={`whitespace-pre-wrap ${
+                                    selectedReport.is_encrypted &&
+                                    getDecryptedReport(selectedReport).message.startsWith("[Encrypted Report")
+                                      ? "italic text-muted-foreground"
+                                      : ""
+                                  }`}>
                                     {selectedReport.is_encrypted
                                       ? getDecryptedReport(selectedReport)
                                           .message

--- a/client/pages/Admin.tsx
+++ b/client/pages/Admin.tsx
@@ -336,29 +336,32 @@ export default function Admin() {
             return legacyDecrypt(report.encrypted_data);
           }
         } catch (error) {
-          console.error("Failed to decrypt report:", error);
+          // Don't log expected encryption errors
+          if (!error.message?.includes("No decryption keys available") &&
+              !error.message?.includes("sessionId")) {
+            console.error("Failed to decrypt report:", error);
+          }
 
           // Fallback to legacy decryption if enhanced fails
           try {
-            console.log("🔄 Falling back to legacy decryption");
             return legacyDecrypt(report.encrypted_data);
           } catch (legacyError) {
-            console.error("Legacy decryption also failed:", legacyError);
+            // Only log unexpected errors, not expected decryption failures
+            if (!legacyError.message?.includes("Incompatible encryption") &&
+                !legacyError.message?.includes("Malformed UTF-8")) {
+              console.error("Legacy decryption also failed:", legacyError);
+            }
 
-            // Provide more specific error messages based on error type
-            let errorMessage = "[DECRYPTION ERROR - Unable to decrypt report]";
+            // Provide clean, user-friendly error messages
+            let errorMessage = "[Encrypted Report - Cannot Display]";
             if (legacyError instanceof SyntaxError && legacyError.message.includes("JSON")) {
-              errorMessage = "[DECRYPTION ERROR - Corrupted video metadata]";
-            } else if (legacyError.message?.includes("Malformed UTF-8")) {
-              errorMessage = "[DECRYPTION ERROR - Wrong encryption key or corrupted data]";
-            } else if (legacyError.message?.includes("Incompatible encryption format")) {
-              errorMessage = "[DECRYPTION ERROR - Report encrypted with different system]";
-            } else if (legacyError.message?.includes("corrupted data") || legacyError.message?.includes("null bytes")) {
-              errorMessage = "[DECRYPTION ERROR - Data corruption detected]";
-            } else if (legacyError.message?.includes("Legacy decryption failed")) {
-              errorMessage = "[DECRYPTION ERROR - Encryption format incompatible]";
-            } else if (legacyError.message?.includes("null data")) {
-              errorMessage = "[DECRYPTION ERROR - Empty encrypted data]";
+              errorMessage = "[Encrypted Report - Metadata Issue]";
+            } else if (legacyError.message?.includes("Malformed UTF-8") ||
+                       legacyError.message?.includes("Incompatible encryption format")) {
+              errorMessage = "[Encrypted Report - Incompatible Format]";
+            } else if (legacyError.message?.includes("corrupted data") ||
+                       legacyError.message?.includes("null bytes")) {
+              errorMessage = "[Encrypted Report - Data Corrupted]";
             }
 
             return {

--- a/client/pages/Admin.tsx
+++ b/client/pages/Admin.tsx
@@ -325,23 +325,25 @@ export default function Admin() {
             password: "satoru 2624", // Current admin password
             sessionId: report.encrypted_data.sessionId,
           });
-        }
 
-        // Use enhanced decryption with admin keys
-        return secureE2EE.decryptReportData(report.encrypted_data, adminKeys);
+          // Use enhanced decryption with admin keys
+          return secureE2EE.decryptReportData(report.encrypted_data, adminKeys);
+        } else {
+          // No sessionId means this was encrypted with legacy system
+          console.log("🔄 No sessionId found, using legacy decryption");
+          return legacyDecrypt(report.encrypted_data);
+        }
       } catch (error) {
         console.error("Failed to decrypt report:", error);
 
         // Fallback to legacy decryption if enhanced fails
         try {
-          // Import legacy decryption function properly for browser environment
-          const { decryptReportData: legacyDecrypt } = await import("@/lib/encryption");
           console.log("🔄 Falling back to legacy decryption");
           return legacyDecrypt(report.encrypted_data);
         } catch (legacyError) {
           console.error("Legacy decryption also failed:", legacyError);
           return {
-            message: "[DECRYPTION ERROR - Enhanced E2EE failed]",
+            message: "[DECRYPTION ERROR - Unable to decrypt report]",
             category: "encrypted",
             photo_url: undefined,
             video_url: undefined,

--- a/client/pages/Admin.tsx
+++ b/client/pages/Admin.tsx
@@ -349,6 +349,8 @@ export default function Admin() {
             errorMessage = "[DECRYPTION ERROR - Corrupted video metadata]";
           } else if (legacyError.message?.includes("Malformed UTF-8")) {
             errorMessage = "[DECRYPTION ERROR - Wrong encryption key or corrupted data]";
+          } else if (legacyError.message?.includes("Incompatible encryption format")) {
+            errorMessage = "[DECRYPTION ERROR - Report encrypted with different system]";
           } else if (legacyError.message?.includes("corrupted data") || legacyError.message?.includes("null bytes")) {
             errorMessage = "[DECRYPTION ERROR - Data corruption detected]";
           } else if (legacyError.message?.includes("Legacy decryption failed")) {

--- a/client/pages/Admin.tsx
+++ b/client/pages/Admin.tsx
@@ -338,7 +338,9 @@ export default function Admin() {
         } catch (error) {
           // Don't log expected encryption errors
           if (!error.message?.includes("No decryption keys available") &&
-              !error.message?.includes("sessionId")) {
+              !error.message?.includes("sessionId") &&
+              !error.message?.includes("Incompatible encryption") &&
+              !error.message?.includes("Legacy decryption failed")) {
             console.error("Failed to decrypt report:", error);
           }
 


### PR DESCRIPTION
## Purpose
Remove the green E2E encryption status badges from the admin UI that were only appearing on some reports, causing inconsistent display. The user wanted to clean up the UI by removing these encryption indicators while ensuring all reports are properly encrypted.

## Code changes
- **Removed encryption status badges**: Eliminated the green "E2E Encrypted" and amber "Plain Text" badges from the admin report list view
- **Enhanced decryption error handling**: Added robust error handling with user-friendly error messages for failed decryptions
- **Improved legacy decryption fallback**: Added `safeDecrypt` helper function with better UTF-8 validation and null byte detection
- **Better video metadata parsing**: Added try-catch blocks around video metadata JSON parsing in both encryption systems
- **Cleaner error messages**: Replaced technical error messages with user-friendly "[Encrypted Report - Cannot Display]" style messages
- **Reduced console noise**: Suppressed expected decryption failure logs while preserving unexpected error logging

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 5`

🔗 [Edit in Builder.io](https://builder.io/app/projects/c19a7294cb3442328a298d83f3695e3f/mystic-home)

👀 [Preview Link](https://c19a7294cb3442328a298d83f3695e3f-mystic-home.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>c19a7294cb3442328a298d83f3695e3f</projectId>-->
<!--<branchName>mystic-home</branchName>-->